### PR TITLE
Avoid to break migrations checking if already exists

### DIFF
--- a/src/Storage/migrations/2018_08_08_100000_create_gauge_entries_table.php
+++ b/src/Storage/migrations/2018_08_08_100000_create_gauge_entries_table.php
@@ -40,20 +40,22 @@ class CreateGaugeEntriesTable extends Migration
      */
     public function up()
     {
-        $this->schema->create('gauge_entries', function (Blueprint $table) {
-            $table->bigIncrements('sequence');
-            $table->uuid('uuid');
-            $table->string('family_hash');
-            $table->string('type', 20);
-            $table->integer('duration');
-            $table->jsonb('content');
-            $table->dateTime('created_at')->nullable();
-
-            $table->unique('uuid');
-            $table->index('family_hash');
-            $table->index('type');
-            $table->index('created_at');
-        });
+        if(!$this->schema->hasTable('gauge_entries')) {
+            $this->schema->create('gauge_entries', function (Blueprint $table) {
+                $table->bigIncrements('sequence');
+                $table->uuid('uuid');
+                $table->string('family_hash');
+                $table->string('type', 20);
+                $table->integer('duration');
+                $table->jsonb('content');
+                $table->dateTime('created_at')->nullable();
+    
+                $table->unique('uuid');
+                $table->index('family_hash');
+                $table->index('type');
+                $table->index('created_at');
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
I was getting this error to re-run the migrations on the test database:

```
Migrating: 2018_08_08_100000_create_gauge_entries_table   Illuminate\Database\QueryException  : SQLSTATE[42P07]: Duplicate table: 7 ERROR:  relation "gauge_entries" already exists (SQL: create table "gauge_entries" ("sequence" bigserial primary key not null, "uuid" uuid not null, "family_hash" varchar(255) not null, "type" varchar(20) not null, "duration" integer not null, "content" jsonb not null, "created_at" timestamp(0) without time zone null))  at /var/www/vendor/laravel/framework/src/Illuminate/Database/Connection.php:669
    665|         // If an exception occurs when attempting to run a query, we'll format the error
    666|         // message to include the bindings with SQL, which will make this exception a
    667|         // lot more helpful to the developer instead of just the database's errors.
    668|         catch (Exception $e) {
  > 669|             throw new QueryException(
    670|                 $query, $this->prepareBindings($bindings), $e
    671|             );
    672|         }
    673|   Exception trace:  1   Doctrine\DBAL\Driver\PDO\Exception::("SQLSTATE[42P07]: Duplicate table: 7 ERROR:  relation "gauge_entries" already exists")
      /var/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDO/Exception.php:18  2   Doctrine\DBAL\Driver\PDO\Exception::new(Object(PDOException))
      /var/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:117
```

To avoid that we can only check if the database already have the related table that is what we have on this PR.